### PR TITLE
fix build error

### DIFF
--- a/src/layout.cpp
+++ b/src/layout.cpp
@@ -5,6 +5,7 @@
 
 #include <algorithm>
 #include <bitset>
+#include <sys/time.h>
 
 layout::layout(sysboard *win, const std::string &keymap_name, const int &max_width) : Gtk::Box(Gtk::Orientation::VERTICAL) {
 	window = win;


### PR DESCRIPTION
installed `sysboard` from AUR and got build error
```cpp
src/layout.cpp: In member function ‘long int layout::get_time_in_us()’:
src/layout.cpp:213:5: error: ‘gettimeofday’ was not declared in this scope
  213 |     gettimeofday(&tv, nullptr);
      |     ^~~~~~~~~~~~
make: *** [Makefile:64: build/layout.o] Error 1
make: *** Waiting for unfinished jobs....
==> ERROR: A failure occurred in build().
    Aborting...
error: failed to build 'sysboard-9.9.9-9':
```

simple fix